### PR TITLE
Add debugging print statements

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -49,6 +49,8 @@ pub fn build_query(
         arcount: 0,
     };
 
+    println!("Header: {:?}", hdr);
+
     // Declare object of type DNSQuestion.
     let qn = DNSQuestion {
         qname: name,
@@ -56,8 +58,14 @@ pub fn build_query(
         qclass: record_class.into(),
     };
 
+    println!("Question: {:?}", qn);
+
     // Concatenate the header and question bytes.
     let mut res = hdr.to_bytes()?;
+
+    println!("Header in bytes: {:?}", hdr.to_bytes()?);
+    println!("Qn in bytes: {:?}", qn.to_bytes()?);
+
     res.append(&mut qn.to_bytes()?);
 
     Ok(res)

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
 }
 
 fn run() -> Result<Vec<u8>, Error> {
-    let query = dns::build_query("www.google.com", QType::A, QClass::IN)?;
+    let query = dns::build_query("www.example.com", QType::A, QClass::IN)?;
 
     // Create a UDP socket
     let socket = UdpSocket::bind("0.0.0.0:0")?;
@@ -36,6 +36,8 @@ fn run() -> Result<Vec<u8>, Error> {
 
     // Receive the DNS response.
     let (_amt, _src) = socket.recv_from(&mut buf)?;
+
+    println!("bytes: {:?}", &buf[.._amt]);
 
     /*
      * TODO: Parse the DNS response from buf[..amt].

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,6 +26,7 @@ pub struct DNSRecord {
 
     /**
      * The type of DNS record, such as A (IPv4 address), AAAA (IPv6 address), CNAME, etc.
+     * Type is QType, an enum, encoded as an integer.
      */
     pub r#type: QType,
 
@@ -38,7 +39,7 @@ pub struct DNSRecord {
     /// The length in octets of the data field.
     pub rdlength: u16,
 
-    /// Additional record-specific data.
+    /// Additional record-specific data, like the IP address.
     pub rdata: Vec<u8>,
 }
 


### PR DESCRIPTION
Working with byte arrays is a bit more complicated than I imagined. I need to have some basic debugging print statements in place. This commit adds that to the code base.